### PR TITLE
Update loading-bar.js

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -207,8 +207,12 @@ angular.module('cfp.loadingBar', [])
           : $document.find($parentSelector)[0]
         ;
 
-        if (! parent) {
+        if (!parent) {
           parent = document.getElementsByTagName('body')[0];
+        }
+        
+        if (!parent) {
+          return;
         }
 
         var $parent = angular.element(parent);


### PR DESCRIPTION


<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**
Sometimes, when you reload a webpage, you get an exception "cannot get property lastChild or undefined", because the variable parent is undefined.
If that is the case we return from the function to avoid the exception

<!-- 
Provide a general description of the code changes in your pull
request. If bugs were fixed, please document the changes and why
they were introduced.

Please ensure that your PR contains test cases that cover all new
code and any changes to existing code. Without tests, your PR is
likely to be closed without merging.
-->

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**
no

**Related issues**
<!--
Please review the (https://github.com/chieffancypants/angular-loading-bar/issues)
page, and link any issues that are addressed or related to this PR.
-->
